### PR TITLE
use info@fossgis.de (local chapter) as generic contact

### DIFF
--- a/resources/europe/de/de-forum.json
+++ b/resources/europe/de/de-forum.json
@@ -7,5 +7,5 @@
   "name": "OpenStreetMap DE forum",
   "description": "OpenStreetMap Germany web forum",
   "url": "https://forum.openstreetmap.org/viewforum.php?id=14",
-  "contacts": [{"name": "Frederik Ramm", "email": "frederik@remote.org"}]
+  "contacts": [{"name": "FOSSGIS e.V.", "email": "info@fossgis.de"}]
 }

--- a/resources/europe/de/de-irc.json
+++ b/resources/europe/de/de-irc.json
@@ -7,5 +7,5 @@
   "languageCodes": ["de"],
   "description": "Join #osm-de on irc.oftc.net (port 6667)",
   "url": "http://de.irc2go.com/webchat/?net=OFTC&room=osm-de",
-  "contacts": [{"name": "Frederik Ramm", "email": "frederik@remote.org"}]
+  "contacts": [{"name": "FOSSGIS e.V.", "email": "info@fossgis.de"}]
 }

--- a/resources/europe/de/de-mailinglist.json
+++ b/resources/europe/de/de-mailinglist.json
@@ -7,5 +7,5 @@
   "languageCodes": ["de"],
   "description": "Talk-de is the official mailing list for the German OSM community",
   "url": "https://lists.openstreetmap.org/listinfo/talk-de",
-  "contacts": [{"name": "Frederik Ramm", "email": "frederik@remote.org"}]
+  "contacts": [{"name": "FOSSGIS e.V.", "email": "info@fossgis.de"}]
 }

--- a/resources/europe/de/osm-de.json
+++ b/resources/europe/de/osm-de.json
@@ -7,5 +7,5 @@
   "name": "OpenStreetMap Germany",
   "description": "The platform for information on OpenStreetMap in Germany",
   "url": "https://www.openstreetmap.de/",
-  "contacts": [{"name": "Frederik Ramm", "email": "frederik@remote.org"}]
+  "contacts": [{"name": "FOSSGIS e.V.", "email": "info@fossgis.de"}]
 }


### PR DESCRIPTION
Even though FOSSGIS e.V., the official OSMF local chapter for Germany, is not the operator of the German Forum, Mailing List, or IRC channel, it sounds most sensible to list them as a contact address. They *are* the operator of openstreetmap.de.