### PR TITLE
fix the OFTC IRC weblink - peer tested

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -129,6 +129,10 @@ en:
   be-forum:
     name: OpenStreetMap BE forum
     description: OpenStreetMap Belgium web forum
+  be-irc:
+    name: OpenStreetMap Belgium IRC
+    description: 'Join #osmbe on irc.oftc.net (port 6667)'
+    extendedDescription: 'Join #osmbe on irc.oftc.net (port 6667) , it is bridged with the matrix chat channel'
   be-mailinglist:
     name: Talk-be Mailing List
     description: Talk-be is the official mailing list for Belgian OSM community

--- a/resources/europe/be/be-irc.json
+++ b/resources/europe/be/be-irc.json
@@ -1,0 +1,12 @@
+{
+  "id": "be-irc",
+  "featureId": "belgium",
+  "type": "irc",
+  "name": "OpenStreetMap Belgium IRC",
+  "countryCodes": ["be"],
+  "languageCodes": ["en", "nl", "fr", "de"],
+  "description": "Join #osmbe on irc.oftc.net (port 6667)",
+  "extendedDescription": "Join #osmbe on irc.oftc.net (port 6667) , it is bridged with the matrix chat channel",
+  "url": "https://webchat.oftc.net/?channels=osmbe",
+  "contacts": [{"name": "BE community", "email": "community@osm.be"}]
+}


### PR DESCRIPTION
This fixes the IRC broken webinterface with the working OFTC official webinterface. It fixed the problem mentioned here : https://github.com/osmlab/osm-community-index/commit/15598db00be4621b73a5f4f247384ede5c11b644#commitcomment-28621809