### PR TITLE
Fix URL of Meetup Berlin

### DIFF
--- a/resources/europe/de/de-berlin-meetup.json
+++ b/resources/europe/de/de-berlin-meetup.json
@@ -6,7 +6,6 @@
   "countryCodes": ["de"],
   "languageCodes": ["de"],
   "description": "Mappers and OpenStreetMap users in the Berlin area",
-  "signupUrl": "https://www.meetup.com/OSM-Berlin-Brandenburg/",
-  "url": "https://meetup.com/",
+  "url": "https://www.meetup.com/OSM-Berlin-Brandenburg/",
   "contacts": [{"name": "Christopher Lorenz", "email": "osm@lorenz.lu"}]
 }


### PR DESCRIPTION
Change signupUrl to url. The current release points to meetup.com only, not to OSM-Berlin-Brandenburg