### PR TITLE
Add OpenStreetMap Italy Telegram

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -242,6 +242,9 @@ en:
   it-mailinglist:
     name: Talk-it Mailing List
     description: Talk-it is the official mailing list for the Italian OSM community
+  it-telegram:
+    name: '@OpenStreetMapItalia on Telegram'
+    description: OpenStreetMap Italy Telegram chat
   it-twitter:
     name: OpenStreetMap Italy Twitter
     description: 'Follow us on Twitter at {url}'

--- a/resources/europe/italy/it-telegram.json
+++ b/resources/europe/italy/it-telegram.json
@@ -1,0 +1,13 @@
+{
+  "id": "it-telegram",
+  "type": "telegram",
+  "featureId": "italy",
+  "countryCodes": ["it"],
+  "languageCodes": ["it"],
+  "name": "@OpenStreetMapItalia on Telegram",
+  "description": "OpenStreetMap Italy Telegram chat",
+  "url": "https://t.me/OpenStreetMapItalia",
+  "contacts": [    {"name": "Simone Cortesi", "email": "simone@cortesi.com"},
+    {"name": "Stefano", "email": "sabas88@gmail.com"},
+    {"name": "Alessandro Palmas", "email": "alessandro.palmas@wikimedia.it"}]
+}


### PR DESCRIPTION
This PR adds the OpenStreetMap Italy Telegram chat, which is also linked on the [Italian WikiProject page](https://wiki.openstreetmap.org/wiki/WikiProject_Italy).