### PR TITLE
Show JSON parse errors & progress bar with summary

### DIFF
--- a/build.js
+++ b/build.js
@@ -46,7 +46,17 @@ function generateFeatures() {
     var files = {};
     glob.sync(__dirname + '/features/**/*.geojson').forEach(function(file) {
         var contents = fs.readFileSync(file, 'utf8');
-        var feature = precision(rewind(JSON.parse(contents), true), 5);
+        var parsed;
+        try {
+            parsed = JSON.parse(contents);
+        } catch (jsonParseError)
+        {
+            console.error(colors.red('Error - ' + jsonParseError.message + ' in:'));
+            console.error('  ' + colors.yellow(file));
+            process.exit(1);
+        }
+
+        var feature = precision(rewind(parsed, true), 5);
         var fc = feature.features;
 
         // A FeatureCollection with a single feature inside (geojson.io likes to make these).
@@ -79,7 +89,16 @@ function generateResources(tstrings, features) {
     var files = {};
     glob.sync(__dirname + '/resources/**/*.json').forEach(function(file) {
         var contents = fs.readFileSync(file, 'utf8');
-        var resource = JSON.parse(contents);
+
+        var resource;
+        try {
+            resource = JSON.parse(contents);
+        } catch (jsonParseError) {
+            console.error(colors.red('Error - ' + jsonParseError.message + ' in:'));
+            console.error('  ' + colors.yellow(file));
+            process.exit(1);
+        }
+
         validateFile(file, resource, resourceSchema);
         prettifyFile(file, resource, contents);
 

--- a/build.js
+++ b/build.js
@@ -44,6 +44,7 @@ function buildAll() {
 function generateFeatures() {
     var features = {};
     var files = {};
+    process.stdout.write('Features:');
     glob.sync(__dirname + '/features/**/*.geojson').forEach(function(file) {
         var contents = fs.readFileSync(file, 'utf8');
         var parsed;
@@ -79,7 +80,11 @@ function generateFeatures() {
         }
         features[id] = feature;
         files[id] = file;
+
+        process.stdout.write(colors.green('✓'));
     });
+
+    process.stdout.write(Object.keys(files).length + '\n');
 
     return features;
 }
@@ -87,6 +92,7 @@ function generateFeatures() {
 function generateResources(tstrings, features) {
     var resources = {};
     var files = {};
+    process.stdout.write('Resources:');
     glob.sync(__dirname + '/resources/**/*.json').forEach(function(file) {
         var contents = fs.readFileSync(file, 'utf8');
 
@@ -170,7 +176,11 @@ function generateResources(tstrings, features) {
                 tstrings[resourceId].events = estrings;
             }
         }
+
+        process.stdout.write(colors.green('✓'));
     });
+
+    process.stdout.write(Object.keys(files).length + '\n');
 
     return resources;
 }


### PR DESCRIPTION
### A bug fix c0eb8cc:
Show also JSON.parse errors nicely when JSON is horribly broken instead of just dumping a stacktrace without pointing out which file is problematic.

### Improvement 21883bf:
Show progress & summary during Feature & Resource generation, eg:
```
building data
Features:✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓91
Resources:✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓180
data built: 246.582ms
```