### PR TITLE
Update the OSM US Slack join URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -76,7 +76,7 @@ Resource files look like this:
   "name": "OpenStreetMap US Slack",
   "description": "All are welcome! Sign up at {signupUrl}",
   "extendedDescription": "OpenStreetMap is built by a community of mappers that..."
-  "signupUrl": "https://osmus-slack.herokuapp.com/",
+  "signupUrl": "https://slack.openstreetmap.us/",
   "url": "https://osmus.slack.com",
   "contacts": [
     {

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -18,7 +18,7 @@ example:  "slack", "forum", "mailing list", "facebook", something else?
 ### URL link to the resource
 
 <!--
-example:  "https://osmus-slack.herokuapp.com/"
+example:  "https://slack.openstreetmap.us/"
 -->
 
 ### Points of contact

--- a/resources/north-america/united_states/OSM-US-Slack.json
+++ b/resources/north-america/united_states/OSM-US-Slack.json
@@ -6,7 +6,7 @@
   "languageCodes": ["en"],
   "name": "OpenStreetMap US Slack",
   "description": "All are welcome! Sign up at {signupUrl}",
-  "signupUrl": "https://osmus-slack.herokuapp.com/",
+  "signupUrl": "https://slack.openstreetmap.us/",
   "url": "https://osmus.slack.com",
   "contacts": [
     {"name": "Ian Dees", "email": "ian@openstreetmap.us"},


### PR DESCRIPTION
In the interest of relying less on Heroku, I'd like to change all these to point to openstreetmap.us domains.