### PR TITLE
Issue 175 | Add OSM discord Json

### DIFF
--- a/resources/world/OSM-Discord.json
+++ b/resources/world/OSM-Discord.json
@@ -1,0 +1,16 @@
+{
+  "id": "OSM-Discord",
+  "type": "discord",
+  "languageCodes": [
+    "en"
+  ],
+  "name": "OpenStreetMap Discord",
+  "description": "Get in touch with other mappers via Discord",
+  "url": "https://discord.gg/SRZUYUz",
+  "contacts": [
+    {
+      "name": "Austin Harrison",
+      "email": "jaustinharrison@gmail.com"
+    }
+  ]
+}


### PR DESCRIPTION
Add Osm Discord Json

```{
  "id": "OSM-Discord",
  "type": "discord",
  "languageCodes": ["en"],
  "name": "OpenStreetMap Discord",
  "description": "Get in touch with other mappers via Discord",
  "url": "https://discord.gg/SRZUYUz",
  "contacts": [{"name": "Austin Harrison", "email": "jaustinharrison@gmail.com"}]
}
```