### PR TITLE
adding in discord id

### DIFF
--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -634,6 +634,9 @@ en:
         name: State of the Map Latam 2018
         description: 'State of the Map Latam is the annual conference for all mappers and users of OpenStreetMap in Latin America. The program includes talks, panels, workshops, and mapathons related to OpenStreetMap.'
         where: 'Buenos Aires, Argentina'
+  OSM-Discord:
+    name: OpenStreetMap Discord
+    description: Get in touch with other mappers via Discord
   OSM-Facebook:
     name: OpenStreetMap on Facebook
     description: Like us on Facebook for news and updates about OpenStreetMap.

--- a/resources/world/OSM-Discord.json
+++ b/resources/world/OSM-Discord.json
@@ -1,0 +1,11 @@
+{
+  "id": "OSM-Discord",
+  "type": "discord",
+  "languageCodes": ["en"],
+  "name": "OpenStreetMap Discord",
+  "description": "Get in touch with other mappers via Discord",
+  "url": "https://discord.gg/SRZUYUz",
+  "contacts": [
+    {"name": "Austin Harrison", "email": "jaustinharrison@gmail.com"}
+  ]
+}


### PR DESCRIPTION
Closes #175 

Brings in the new `resources` file to point to the Discord group for OSM