### PR TITLE
re-order Australian resources

### DIFF
--- a/resources/oceania/Maptime-Oceania-Slack.json
+++ b/resources/oceania/Maptime-Oceania-Slack.json
@@ -13,5 +13,5 @@
     {"name": "Philip Mallis", "email": "philip.mallis@unimelb.edu.au"},
     {"name": "Edoardo Neerhut", "email": "ed@mapillary.com"}
   ],
-  "order": 4
+  "order": 3
 }

--- a/resources/oceania/australia/geogeeks_perth.json
+++ b/resources/oceania/australia/geogeeks_perth.json
@@ -7,5 +7,6 @@
   "name": "GeoGeeks Perth Meetup",
   "description": "Perth-based meetup group for people interested in mapping, geospatial data, and open source. We'll be working on anything that involves a sense of place.",
   "url": "https://geogeeks.org",
-  "contacts": [{"name": "GeoGeeks Perth", "email": "geogeeks.perth@gmail.com"}]
+  "contacts": [{"name": "GeoGeeks Perth", "email": "geogeeks.perth@gmail.com"}],
+  "order": 0
 }

--- a/resources/oceania/australia/talk-au.json
+++ b/resources/oceania/australia/talk-au.json
@@ -12,5 +12,5 @@
     {"name": "Steve Bennett", "email": "stevagewp@gmail.com"},
     {"name": "Ian Sergeant", "email": "inas66+osm@gmail.com"}
   ],
-  "order": -3
+  "order": 4
 }


### PR DESCRIPTION
Justification being that talk-au is currently the most active place for
OSM discussion, followed by the Maptime Oceania Slack which does get
used, but less than talk-au.