### PR TITLE
North and South Korea

### DIFF
--- a/resources/asia/north_korea/OSM-KO-mailinglist.json
+++ b/resources/asia/north_korea/OSM-KO-mailinglist.json
@@ -1,0 +1,14 @@
+{
+  "id": "OSM-KO-mailinglist",
+  "featureId": "north_korea",
+  "type": "mailinglist",
+  "name": "OpenStreetMap Korea Mailinglist",
+  "countryCodes": ["ko"],
+  "languageCodes": ["ko", "en"],
+  "description": "Talk-ko is an Official Mailinglist for the Communities to dicuss matters about South and North Korea",
+  "url": "https://lists.openstreetmap.org/listinfo/talk-ko",
+  "contacts": [
+    {"name": "Talk-ko-owner", "email": "talk-ko-owner@openstreetmap.org"}
+  ],
+  "order": -3
+}

--- a/resources/asia/north_korea/OSM-korea-telegram.json
+++ b/resources/asia/north_korea/OSM-korea-telegram.json
@@ -1,0 +1,14 @@
+{
+  "id": "OSM-korea-telegram",
+  "featureId": "north_korea",
+  "type": "telegram",
+  "countryCodes": ["kr"],
+  "languageCodes": ["ko", "en"],
+  "name": "OSM Korea Telegram",
+  "description": "Unofficial Group for OpenStreetMap contributors, communities, and users in South Korea to share and discuss.",
+  "url": "https://t.me/osmKorea",
+  "contacts": [
+    {"name": "Yongmin Hong", "email": "revi@pobox.com"},
+    {"name": "Max N", "email": "abonnements@revolwear.com"}
+  ]
+}

--- a/resources/asia/south_korea/OSM-KO-mailinglist.json
+++ b/resources/asia/south_korea/OSM-KO-mailinglist.json
@@ -1,0 +1,14 @@
+{
+  "id": "OSM-KO-mailinglist",
+  "featureId": "korea",
+  "type": "mailinglist",
+  "name": "OpenStreetMap Korea Mailinglist",
+  "countryCodes": ["ko"],
+  "languageCodes": ["ko", "en"],
+  "description": "Talk-ko is an Official Mailinglist for the Communities to dicuss matters about South and North Korea",
+  "url": "https://lists.openstreetmap.org/listinfo/talk-ko",
+  "contacts": [
+    {"name": "Talk-ko-owner", "email": "talk-ko-owner@openstreetmap.org"}
+  ],
+  "order": -3
+}

--- a/resources/asia/south_korea/OSM-korea-telegram.json
+++ b/resources/asia/south_korea/OSM-korea-telegram.json
@@ -1,11 +1,11 @@
 {
-  "id": "OSM-south-korea-telegram",
+  "id": "OSM-korea-telegram",
   "featureId": "south_korea",
   "type": "telegram",
   "countryCodes": ["kr"],
   "languageCodes": ["ko", "en"],
-  "name": "OSM South Korea Telegram",
-  "description": "Unofficial Channnel for OpenStreetMap contributors, communities, and users in South Korea to share and discuss.",
+  "name": "OSM Korea Telegram",
+  "description": "Unofficial Group for OpenStreetMap contributors, communities, and users in South Korea to share and discuss.",
   "url": "https://t.me/osmKorea",
   "contacts": [
     {"name": "Yongmin Hong", "email": "revi@pobox.com"},


### PR DESCRIPTION
Both Mailinglist as well as Telegram group are covering South and North Korea. Please also allow me to note that North Koreans will be offended by refering their country as such. The proper term would be _Democratic People's Republic of Korea_ or _DPRK_. 