### PR TITLE
Corrected languageCodes ua->uk for Ukrainian

### DIFF
--- a/resources/europe/ukraine/ua-facebook.json
+++ b/resources/europe/ukraine/ua-facebook.json
@@ -3,7 +3,7 @@
   "featureId": "ukraine",
   "type": "facebook",
   "countryCodes": ["ua"],
-  "languageCodes": ["ua"],
+  "languageCodes": ["uk"],
   "name": "OpenStreetMap Ukraine Facebook group",
   "description": "Join the OpenStreetMap Ukraine community on Facebook",
   "url": "https://www.facebook.com/openstreetmapua/",

--- a/resources/europe/ukraine/ua-forum.json
+++ b/resources/europe/ukraine/ua-forum.json
@@ -3,7 +3,7 @@
   "featureId": "ukraine",
   "type": "forum",
   "countryCodes": ["ua"],
-  "languageCodes": ["ua", "ru"],
+  "languageCodes": ["uk", "ru", "en"],
   "name": "OpenStreetMap Ukraine Forum",
   "description": "Forum of OpenStreetMap community in Ukraine",
   "url": "https://forum.openstreetmap.org/viewforum.php?id=40",

--- a/resources/europe/ukraine/ua-github.json
+++ b/resources/europe/ukraine/ua-github.json
@@ -3,7 +3,7 @@
   "featureId": "ukraine",
   "type": "github",
   "countryCodes": ["ua"],
-  "languageCodes": ["ua", "en"],
+  "languageCodes": ["uk", "en"],
   "name": "OpenStreetMap Ukraine on GitHub",
   "description": "OpenStreetMap Ukraine GitHub",
   "url": "https://github.com/osm-ua/",

--- a/resources/europe/ukraine/ua-slack.json
+++ b/resources/europe/ukraine/ua-slack.json
@@ -3,7 +3,7 @@
   "featureId": "ukraine",
   "type": "slack",
   "countryCodes": ["ua"],
-  "languageCodes": ["ua", "ru"],
+  "languageCodes": ["uk", "en", "ru"],
   "name": "OpenStreetMap Ukraine Slack",
   "description": "Join the OpenStreetMap Ukraine community on Slack",
   "url": "https://osmukraine.slack.com/",

--- a/resources/europe/ukraine/ua-telegram.json
+++ b/resources/europe/ukraine/ua-telegram.json
@@ -3,7 +3,7 @@
   "featureId": "ukraine",
   "type": "telegram",
   "countryCodes": ["ua"],
-  "languageCodes": ["ua", "ru", "en"],
+  "languageCodes": ["uk", "ru", "en"],
   "name": "@osmUA on Telegram",
   "description": "OpenStreetMap Ukraine Telegram chat",
   "url": "https://t.me/osmUA",

--- a/resources/europe/ukraine/ua-twitter.json
+++ b/resources/europe/ukraine/ua-twitter.json
@@ -3,7 +3,7 @@
   "featureId": "ukraine",
   "type": "twitter",
   "countryCodes": ["ua"],
-  "languageCodes": ["ua"],
+  "languageCodes": ["uk"],
   "name": "OpenStreetMap UA Twitter",
   "description": "OpenStreetMap Ukraine on Twitter: {url}",
   "url": "https://twitter.com/osm_ua",

--- a/resources/europe/ukraine/ua-website.json
+++ b/resources/europe/ukraine/ua-website.json
@@ -3,7 +3,7 @@
   "featureId": "ukraine",
   "type": "osm",
   "countryCodes": ["ua"],
-  "languageCodes": ["ua"],
+  "languageCodes": ["uk"],
   "name": "OpenStreetMap Website Ukraine",
   "description": "OpenStreetMap website in Ukraine",
   "url": "https://openstreetmap.org.ua/",


### PR DESCRIPTION
Fixed initially incorrectly submitted languageCodes "ua" for Ukrainian language. Should be "uk" instead.