### PR TITLE
Fix location of Rio Grande do Sul

### DIFF
--- a/features/south-america/brazil/riograndedosul.geojson
+++ b/features/south-america/brazil/riograndedosul.geojson
@@ -1,0 +1,9 @@
+{
+  "type": "Feature",
+  "id": "riograndedosul",
+  "properties": {},
+  "geometry": {
+    "type": "Polygon",
+    "coordinates": [[[-53.8, -26.3], [-48.6, -28.9], [-53.1, -34], [-57.7, -30.2]]]
+  }
+}

--- a/resources/south-america/brazil/RS-telegram.json
+++ b/resources/south-america/brazil/RS-telegram.json
@@ -1,7 +1,7 @@
 {
   "id": "RS-telegram",
   "type": "telegram",
-  "includeLocations": ["rs"],
+  "includeLocations": ["riograndedosul.geojson"],
   "countryCodes": ["br"],
   "languageCodes": ["pt"],
   "name": "OpenStreetMap Rio Grande do Sul Telegram Group",


### PR DESCRIPTION
This had been incorrectly defined as "rs" (Serbia).  Create a simple GeoJSON
enclosing it and change the definition of the Telegram group to use that.