### PR TITLE
Matrix information for Kosovo community updated

### DIFF
--- a/resources/europe/kosovo/kosovo-matrix.json
+++ b/resources/europe/kosovo/kosovo-matrix.json
@@ -6,5 +6,5 @@
   "languageCodes": ["en", "sq", "sr"],
   "name": "OpenStreetMap Kosovo on Matrix (bridged with the one in Telegram)",
   "description": "Semi-official all-Kosovo public group. We welcome all mappers from anywhere in any language.",
-  "url": "https://riot.im/app/#/room/#telegram_osmkosovo:t2bot.io"
+  "url": "https://riot.im/app/#/room/#osmkosovo:matrix.org"
 }


### PR DESCRIPTION
This commit contains the updated url. We needed to close the previous one because that one was created by the portal bot. The OSM community shouldn't use groups that cannot be full controlled by the community. Previously I was just Moderator and not Owner. Communities have been/will be informed about the change.