### PR TITLE
Add Japan OpenStreetMap Slack workspace

### DIFF
--- a/resources/asia/japan/OSM-Japan-slack.json
+++ b/resources/asia/japan/OSM-Japan-slack.json
@@ -1,0 +1,11 @@
+{
+  "id": "OSM-japan-slack",
+  "type": "slack",
+  "locationSet": {"include": ["jp"]},
+  "languageCodes": ["ja"],
+  "name": "OpenStreetMap Japan Slack",
+  "description": "A Slack workspace for the OSM Japan community {signupUrl}",
+  "url": "osm-japan.slack.com",
+  "signupUrl": "https://join.slack.com/t/osm-japan/shared_invite/zt-d0my5ek2-SRxGCIsPPIyaOWkJOZ4EMg",
+  "contacts": [{"name": "OSMF Japan", "email": "info@osmf.jp"}]
+}


### PR DESCRIPTION
Slack workspace for Japanese mappers and users has been [set](https://twitter.com/osmfj/status/1243826444221865984).

I'd like  to add channel using this information.
Please let me know if you have any missing  information or wrong format.

Tested with `npm run test` on my env are here:

```
Suites:   1 passed, 1 of 1 completed
Asserts:  6 passed, of 6
Time:     6s
----------|----------|----------|----------|----------|-------------------|
File      |  % Stmts | % Branch |  % Funcs |  % Lines | Uncovered Line #s |
----------|----------|----------|----------|----------|-------------------|
All files |      100 |       30 |      100 |      100 |                   |
 index.js |      100 |       30 |      100 |      100 |             2,3,4 |
----------|----------|----------|----------|----------|-------------------|
```