### PR TITLE
Add missing HTTP(S) to URL

### DIFF
--- a/resources/africa/guinea/ym-General-Lansana-Conte-University.json
+++ b/resources/africa/guinea/ym-General-Lansana-Conte-University.json
@@ -5,6 +5,6 @@
   "name": "YouthMappers General Lansana Conte University",
   "description": "YouthMappers chapter at General Lansana Conte University",
   "extendedDescription": "The YouthMappers of the University General Lansana Conté is a non profit community willing to contribute to Map Guinea and others part of the world. We are promoting the use of GIS and Open data to build decision support tools. We also work to build capacities among the students and local communities.",
-  "url": "www.uglc.org",
+  "url": "http://www.uglc.org/",
   "contacts": [{"name": "Organizer", "email": "condefa3@gmail.com"}]
 }

--- a/resources/africa/kenya/ym-University-of-Nairobi.json
+++ b/resources/africa/kenya/ym-University-of-Nairobi.json
@@ -5,6 +5,6 @@
   "name": "Geospatial Engineering Students Association",
   "description": "YouthMappers chapter at University of Nairobi",
   "extendedDescription": "UN students are working with the local OSM community, Map Kibera, and GrouthTruth to learn about open mapping and contribute data for needs in their urban communities.",
-  "url": "www.geospatial.uonbi.ac.ke",
+  "url": "http://www.geospatial.uonbi.ac.ke/",
   "contacts": [{"name": "Organizer", "email": "contact@mapkibera.org"}]
 }

--- a/resources/africa/mozambique/ym-Universidade-Eduardo-Mondlane.json
+++ b/resources/africa/mozambique/ym-Universidade-Eduardo-Mondlane.json
@@ -5,6 +5,6 @@
   "name": "Comunidade YouthMappers Moçambique",
   "description": "YouthMappers chapter at Universidade Eduardo Mondlane",
   "extendedDescription": "We are a student group that intends to join Mozambican society to create a resilient community of humanitarian mapping. The community intend to map the physical occupation of our Country and create open geographic data, accessible to the public and able to be used in several areas without associated costs.",
-  "url": "www.facebook.com/Moz-YouthMappers",
+  "url": "https://www.facebook.com/Moz-YouthMappers",
   "contacts": [{"name": "Organizer", "email": "moz.youthmappers1@hotmail.com"}]
 }

--- a/resources/africa/rwanda/ym-Insititue-d-Enseignement-Superieur-de-Ruhengeri.json
+++ b/resources/africa/rwanda/ym-Insititue-d-Enseignement-Superieur-de-Ruhengeri.json
@@ -5,6 +5,6 @@
   "name": "YouthMappers at INES Ruhengeri",
   "description": "YouthMappers chapter at Insititue d' Enseignement Superieur de Ruhengeri",
   "extendedDescription": "We are students from Land Administration and Management and Land survey Departments from INES-Ruhengeri. We are engaged in mapping activities that create the changes toward sustainable development in our community.",
-  "url": "www.ines.ac.rw",
+  "url": "https://www.ines.ac.rw/",
   "contacts": [{"name": "Organizer", "email": "dufitesaie91@yahoo.com"}]
 }

--- a/resources/africa/tanzania/ym-Institute-of-Rural-Development-Planning-Mwanza.json
+++ b/resources/africa/tanzania/ym-Institute-of-Rural-Development-Planning-Mwanza.json
@@ -4,6 +4,6 @@
   "locationSet": {"include": [[32.89851, -2.51658]]},
   "name": "Youth Mappers Chapter at Institute of Rural Development Planning - Lake Zone Centre",
   "description": "YouthMappers chapter at Institute of Rural Development Planning Mwanza",
-  "url": "www.facebook.com/IYMLZC/",
+  "url": "https://www.facebook.com/IYMLZC/",
   "contacts": [{"name": "Organizer", "email": "shabanimagawila@gmail.com"}]
 }

--- a/resources/asia/japan/OSM-Japan-slack.json
+++ b/resources/asia/japan/OSM-Japan-slack.json
@@ -5,7 +5,7 @@
   "languageCodes": ["ja"],
   "name": "OpenStreetMap Japan Slack",
   "description": "A Slack workspace for the OSM Japan community {signupUrl}",
-  "url": "osm-japan.slack.com",
+  "url": "https://osm-japan.slack.com/",
   "signupUrl": "https://join.slack.com/t/osm-japan/shared_invite/zt-d0my5ek2-SRxGCIsPPIyaOWkJOZ4EMg",
   "contacts": [{"name": "OSMF Japan", "email": "info@osmf.jp"}]
 }

--- a/resources/asia/nepal/ym-Kathmandu-University.json
+++ b/resources/asia/nepal/ym-Kathmandu-University.json
@@ -5,6 +5,6 @@
   "name": "Geomatics Engineering Society,GES",
   "description": "YouthMappers chapter at Kathmandu University",
   "extendedDescription": "Geomatics Engineering Society (GES) established in 2008 A.D is a departmental club under Department of Civil and Geomatics Engineering (DCGE) at Kathmandu University. GES acts as a platform to develop the skills of students apart from their educational activities by focusing on activities like technical trainings, seminars, talk programs and interaction with experts from related field, sports activities etc.",
-  "url": "ku.edu.np/ges",
+  "url": "https://ku.edu.np/ges",
   "contacts": [{"name": "Organizer", "email": "ges@ku.edu.np"}]
 }

--- a/resources/north-america/united_states/ym-University-of-Northern-Colorado.json
+++ b/resources/north-america/united_states/ym-University-of-Northern-Colorado.json
@@ -5,6 +5,6 @@
   "name": "UNCO Geography and GIS Club",
   "description": "YouthMappers chapter at University of Northern Colorado",
   "extendedDescription": "Official Geography and GIS Club chapter affiliated with the University of Northern Colorado where our aim is to learn, share and connect with those around us. #MakingSenseOfTheWorld",
-  "url": "www.facebook.com/groups/476365076071166/",
+  "url": "https://www.facebook.com/groups/476365076071166/",
   "contacts": [{"name": "Organizer", "email": "uncogeoggisclub@gmail.com"}]
 }


### PR DESCRIPTION
Building the new static version of the OSM Community Index Viewer, I found out some URL where `http(s)://` is missing.

Warning: some URL's do not seem valid (404):
- http://www.geospatial.uonbi.ac.ke/
- https://www.facebook.com/Moz-YouthMappers
- https://ku.edu.np/ges (correct URL seems to be http://ges.ku.edu.np/)