### PR TITLE
Fix Matrix links

### DIFF
--- a/resources/asia/india/osm-puducherry-matrix.json
+++ b/resources/asia/india/osm-puducherry-matrix.json
@@ -5,7 +5,7 @@
   "name": "Free Software Hardware Movement - Matrix",
   "description": "FSHM Riot group to discuss, share and update mapping activities, events in and around Puducherry",
   "extendedDescription": "FSHM community members share their OSM mapping updates / experiences through the Riot.im group, this group is also used to discuss things related to free software / hardware, technology and activism.",
-  "url": "https://riot.im/app/#/room/#fshm:matrix.org",
+  "url": "https://matrix.to/#/#fshm:matrix.org",
   "contacts": [
     {"name": "Kamalavelan", "email": "sskamalavelan@gmail.com", "osm": "demonshreder"},
     {"name": "Prasanna", "email": "prasmailme@gmail.com", "osm": "Prashere"}

--- a/resources/asia/malaysia/OSM-MY-matrix.json
+++ b/resources/asia/malaysia/OSM-MY-matrix.json
@@ -4,7 +4,7 @@
   "locationSet": {"include": ["my"]},
   "languageCodes": ["en", "ms"],
   "name": "OpenStreetMap Malaysia Riot channel",
-  "description": "All mappers are welcome! Sign up at {signupUrl}",
+  "description": "All mappers are welcome! Sign up at {url}",
   "url": "https://matrix.to/#/#OpenstreetmapMalaysia:matrix.org",
   "contacts": [{"name": "Ahmad Amsyar", "email": "OfficiallyAhmad@protonmail.ch"}]
 }

--- a/resources/asia/malaysia/OSM-MY-matrix.json
+++ b/resources/asia/malaysia/OSM-MY-matrix.json
@@ -5,7 +5,6 @@
   "languageCodes": ["en", "ms"],
   "name": "OpenStreetMap Malaysia Riot channel",
   "description": "All mappers are welcome! Sign up at {signupUrl}",
-  "url": "https://riot.im/app/#/room/#OpenstreetmapMalaysia:matrix.org",
-  "signupUrl": "https://riot.im/app/#/register",
+  "url": "https://matrix.to/#/#OpenstreetmapMalaysia:matrix.org",
   "contacts": [{"name": "Ahmad Amsyar", "email": "OfficiallyAhmad@protonmail.ch"}]
 }

--- a/resources/europe/greece/gr-matrix.json
+++ b/resources/europe/greece/gr-matrix.json
@@ -4,7 +4,7 @@
   "locationSet": {"include": ["gr"]},
   "languageCodes": ["el"],
   "name": "OpenStreetMap Greece Matrix",
-  "description": "Join #osm-gr:matrix.org at https://riot.im/app/#/room/%23osm-gr:matrix.org",
-  "url": "https://riot.im/app/#/room/%23osm-gr:matrix.org",
+  "description": "Join #osm-gr:matrix.org at https://matrix.to/#/#osm-gr:matrix.org",
+  "url": "https://matrix.to/#/#osm-gr:matrix.org",
   "order": 2
 }

--- a/resources/europe/greece/gr-matrix.json
+++ b/resources/europe/greece/gr-matrix.json
@@ -4,7 +4,7 @@
   "locationSet": {"include": ["gr"]},
   "languageCodes": ["el"],
   "name": "OpenStreetMap Greece Matrix",
-  "description": "Join #osm-gr:matrix.org at https://matrix.to/#/#osm-gr:matrix.org",
+  "description": "Join #osm-gr:matrix.org at {url}",
   "url": "https://matrix.to/#/#osm-gr:matrix.org",
   "order": 2
 }

--- a/resources/europe/hungary/hu-matrix.json
+++ b/resources/europe/hungary/hu-matrix.json
@@ -6,6 +6,6 @@
   "name": "OpenStreetMap HU matrix room",
   "description": "OpenStreetMap Hungary matrix chat",
   "extendedDescription": "OpenStreetMap chat on map topics. One of the OSM community support forums.",
-  "url": "https://riot.grin.hu/#/room/#osm:grin.hu",
+  "url": "https://matrix.to/#/#osm:grin.hu",
   "contacts": [{"name": "Peter 'grin' Gervai", "email": "grin@grin.hu"}]
 }

--- a/resources/europe/kosovo/kosovo-matrix.json
+++ b/resources/europe/kosovo/kosovo-matrix.json
@@ -5,5 +5,5 @@
   "languageCodes": ["en", "sq", "sr"],
   "name": "OpenStreetMap Kosovo on Matrix (bridged with the one in Telegram)",
   "description": "Semi-official all-Kosovo public group. We welcome all mappers from anywhere in any language.",
-  "url": "https://riot.im/app/#/room/#osmkosovo:matrix.org"
+  "url": "https://matrix.to/#/#osmkosovo:matrix.org"
 }

--- a/resources/europe/luxembourg/lu-matrix.json
+++ b/resources/europe/luxembourg/lu-matrix.json
@@ -6,6 +6,6 @@
   "name": "OpenStreetMap LU Matrix channel",
   "description": "Everyone is welcome!",
   "extendedDescription": "Feel free to join our Matrix Chat Room! Let's bring the community together.",
-  "url": "https://app.element.io/#/room/#osmlu:matrix.org",
+  "url": "https://matrix.to/#/#osmlu:matrix.org",
   "contacts": [{"name": "OSM Luxembourg", "email": "contact@openstreetmap.lu"}]
 }


### PR DESCRIPTION
Following resources already use the Matrix link:
- Belgium (see #375)
- Germany: [`de-matrix.json`](https://github.com/osmlab/osm-community-index/blob/main/resources/europe/germany/de-matrix.json#L8)
- Peru: [`OSM-PE-matrix.json`](https://github.com/osmlab/osm-community-index/blob/main/resources/south-america/peru/OSM-PE-matrix.json#L8)
- Latam: [`latam-matrix.json`](https://github.com/osmlab/osm-community-index/blob/main/resources/world/latam-matrix.json#L8)

Germany Matrix link could be replaced by short version for consistency (ping @duncanturk)

Close #366