### PR TITLE
Correct region of UK local chapter

### DIFF
--- a/resources/europe/united_kingdom/uk-localchapter.json
+++ b/resources/europe/united_kingdom/uk-localchapter.json
@@ -11,4 +11,3 @@
   "contacts": [{"name": "OpenStreetMap UK", "email": "board@osmuk.org"}],
   "order": 3
 }
-

--- a/resources/europe/united_kingdom/uk-localchapter.json
+++ b/resources/europe/united_kingdom/uk-localchapter.json
@@ -1,7 +1,7 @@
 {
   "id": "uk-localchapter",
   "type": "osm-lc",
-  "locationSet": {"include": ["gb"]},
+  "locationSet": {"include": ["GB-ENG", "GB-NIR", "GB-SCT", "GB-WLS", "JE", "GG", "IM"]},
   "languageCodes": ["en"],
   "name": "OpenStreetMap UK",
   "description": "The official Local Chapter for the UK (including Northern Ireland).",
@@ -11,3 +11,4 @@
   "contacts": [{"name": "OpenStreetMap UK", "email": "board@osmuk.org"}],
   "order": 3
 }
+


### PR DESCRIPTION
The OSM Local Chapter covers England, Scotland, Wales, Northern Ireland, the Channel Islands and Isle of Man. This change better reflects the region and has been tested on the Location Conflation test site:

The change:
https://ideditor.github.io/location-conflation/?locationSet=%7B%20include%3A%20%5B%22GB-ENG%22%2C%20%22GB-NIR%22%2C%20%22GB-SCT%22%2C%20%22GB-WLS%22%2C%20%22JE%22%2C%20%22GG%22%2C%20%22IM%22%5D%7D

Note that this is the same as ["GB-ENG", "GB-NIR", "GB-SCT", "GB-WLS", "830", "833"] but I have used ["GB-ENG", "GB-NIR", "GB-SCT", "GB-WLS", "JE", "GG", "IM"] rather than mixing ISO alpha codes with UN M49 numbers.

The original:
https://ideditor.github.io/location-conflation/?locationSet=%7B%20include%3A%20%5B%22GB%22%5D%7D%0A

FWIW the region shown for ISO code GB is likely to be incorrect. The ISO website describes it (https://www.iso.org/obp/ui/#iso:code:3166:GB) as "the United Kingdom of Great Britain and Northern Ireland". It is not including the Crown Dependencies or the British Overseas Territories and all of these have their own ISO codes such as IM for Ilse of Man and IO for the British Indian Ocean Territory. When the OSM UK organisation was founded we decided to include the Crown Dependencies given their close proximity to mainland Great Britain as set out in our Articles of Association (https://osmuk.org/wp-content/uploads/2016/12/UKOSM_Articles.pdf).
https://en.wikipedia.org/wiki/United_Kingdom#Dependencies

Related alternate change is https://github.com/ideditor/country-coder/issues/35
