### PR TITLE
Correct OSM World server name

### DIFF
--- a/resources/world/OSM-Discord.json
+++ b/resources/world/OSM-Discord.json
@@ -3,7 +3,7 @@
   "type": "discord",
   "locationSet": {"include": ["001"]},
   "languageCodes": ["de", "en", "es", "fr", "it", "pt-BR", "ro", "tr"],
-  "name": "OpenStreetMap Discord",
+  "name": "OpenStreetMap World Discord",
   "description": "Get in touch with other mappers via Discord",
   "url": "https://discord.gg/4smYkq3gzp",
   "contacts": [{"name": "Austin Harrison", "email": "jaustinharrison@gmail.com"}],


### PR DESCRIPTION
The Discord server is called "OpenStreetMap World".