### PR TITLE
telegram/OSM_de is now called "OSM D-A-CH"

### DIFF
--- a/resources/europe/germany/de-telegram.json
+++ b/resources/europe/germany/de-telegram.json
@@ -1,10 +1,10 @@
 {
   "id": "de-telegram",
   "type": "telegram",
-  "locationSet": {"include": ["de"]},
+  "locationSet": {"include": ["de", "at", "ch"]},
   "languageCodes": ["de"],
-  "name": "OpenStreetMap Germany Telegram",
-  "description": "Join the OpenStreetMap Germany Telegram supergroup at {url}",
+  "name": "OpenStreetMap D-A-CH Telegram",
+  "description": "Join the OpenStreetMap D-A-CH Telegram supergroup at {url}",
   "url": "https://t.me/OSM_de",
   "contacts": [{"name": "Max N", "email": "abonnements@revolwear.com"}]
 }


### PR DESCRIPTION
telegram/OSM_de is now called "OSM D-A-CH" (for Germany, Austria and Switzerland) - added at and ch to the locationSet.