### PR TITLE
Queen Mary uni listing london geometry

### DIFF
--- a/resources/europe/united_kingdom/ym-Queen-Mary-University-of-London.json
+++ b/resources/europe/united_kingdom/ym-Queen-Mary-University-of-London.json
@@ -1,7 +1,8 @@
 {
   "id": "ym-Queen-Mary-University-of-London",
   "type": "youthmappers",
-  "locationSet": {"include": [[-0.04049, 51.52382]]},
+  "locationSet": {"include": ["london.geojson"]},
+  "order": 2,
   "strings": {
     "name": "Queen Mary YouthMappers",
     "description": "YouthMappers chapter at Queen Mary University of London",


### PR DESCRIPTION
Swap the geometry for Queen Mary YouthMappers (Queen Mary University of London group) listing, to use london.geojson the same as the "main" OSMLondon group. This has the effect of demoting it in the listings slightly. Previously this had its own point centred geometry which overlapped most of London resulting a top listing above OSMLondon.