### PR TITLE
Update OSM World Discord to the new vanity URL

### DIFF
--- a/resources/world/OSM-Discord.json
+++ b/resources/world/OSM-Discord.json
@@ -1,7 +1,7 @@
 {
   "id": "OSM-Discord",
   "type": "discord",
-  "account": "4smYkq3gzp",
+  "account": "openstreetmap",
   "locationSet": {"include": ["001"]},
   "languageCodes": [
     "de",


### PR DESCRIPTION
The OSM World Discord recently got a vanity URL, this updates the index to the vanity invite ID from the old invite ID.
The old invite ID still works (for now), but it's best to change it.