### PR TITLE
Update be-matrix.json

### DIFF
--- a/resources/europe/belgium/be-matrix.json
+++ b/resources/europe/belgium/be-matrix.json
@@ -1,14 +1,14 @@
 {
   "id": "be-matrix",
   "type": "matrix",
-  "account": "+osmbe",
+  "account": "#osmbe",
   "locationSet": {"include": ["be"]},
   "languageCodes": ["de", "en", "fr", "nl"],
   "order": 6,
   "strings": {
     "community": "OpenStreetMap Belgium",
     "description": "All mappers are welcome!",
-    "extendedDescription": "Most talk is happening at the \"OpenStreetMap Belgium\" channel. You can ask anything there! The other rooms are for specific subjects."
+    "extendedDescription": "Main chatroom of the Belgian OSM community. Don't hesitate to ask beginner questions here!"
   },
   "contacts": [{"name": "BE community", "email": "community@osm.be"}]
 }


### PR DESCRIPTION
This link refered to the deprecated Community concept, which has been replaced with Spaces. However, for beginners, it's probably easier to just wind up in the actual main chatroom, and not on the long list of topical chats.