### PR TITLE
Improve small area warning

### DIFF
--- a/scripts/build_index.js
+++ b/scripts/build_index.js
@@ -131,11 +131,7 @@ function collectFeatures() {
       const extent = geojsonBounds.extent(feature);
       const lon = ((extent[0] + extent[2]) / 2).toFixed(4);
       const lat = ((extent[1] + extent[3]) / 2).toFixed(4);
-      const lon_diff_1 = Math.abs(lon - extent[0]);
-      const lon_diff_2 = Math.abs(lon - extent[2]);
-      const lat_diff_1 = Math.abs(lat - extent[1]);
-      const lat_diff_2 = Math.abs(lat - extent[3]);
-      const dia = (Math.max(lon_diff_1, lon_diff_2, lat_diff_1, lat_diff_1) * 111.139).toFixed(2);
+      const dia = (Math.max(Math.abs(lon - extent[0]), Math.abs(lon - extent[2]), Math.abs(lat - extent[1]), Math.abs(lat - extent[3])) * 111.139).toFixed(2);
       const area_circ = ((dia/2)*(dia/2)*Math.PI).toFixed(2);
       console.warn('');
       console.warn(chalk.yellow(`Warning for ` + chalk.yellow(file) + `:`));

--- a/scripts/build_index.js
+++ b/scripts/build_index.js
@@ -131,9 +131,16 @@ function collectFeatures() {
       const extent = geojsonBounds.extent(feature);
       const lon = ((extent[0] + extent[2]) / 2).toFixed(4);
       const lat = ((extent[1] + extent[3]) / 2).toFixed(4);
+      const lon_diff_1 = Math.abs(lon - extent[0]);
+      const lon_diff_2 = Math.abs(lon - extent[2]);
+      const lat_diff_1 = Math.abs(lat - extent[1]);
+      const lat_diff_2 = Math.abs(lat - extent[3]);
+      const dia = (Math.max(lon_diff_1, lon_diff_2, lat_diff_1, lat_diff_1) * 111.139).toFixed(2);
+      const area_circ = ((dia/2)*(dia/2)*Math.PI).toFixed(2);
       console.warn('');
-      console.warn(chalk.yellow(`Warning - GeoJSON feature for small area (${area} km²).  Consider circular include location instead: [${lon}, ${lat}]`));
-      console.warn('  ' + chalk.yellow(file));
+      console.warn(chalk.yellow(`Warning for ` + chalk.yellow(file) + `:`));
+      console.warn(chalk.yellow(`GeoJSON feature for small area (${area} km²).`));
+      console.warn(chalk.yellow(`Consider circular include location instead: [${lon}, ${lat}] with a diameter of ${dia} km, which than has an area of ${area_circ} km².`));
     }
 
     // use the filename as the feature.id


### PR DESCRIPTION
When the area in a geoJSON file is smaller than 2000 km², the build script warns and suggests to use a circular include rather than the (probably) larger geoJSON file.

With this PR, the warning will also calculate and show a diameter that should include all the maximum extents of the file. 