### PR TITLE
Remove "Openstreetmap Côte d'Ivoire" Telegram chat - it is actually a dead announcement channel

### DIFF
--- a/resources/africa/cote_d'_ivoire/ci-telegram-osm.json
+++ b/resources/africa/cote_d'_ivoire/ci-telegram-osm.json
@@ -1,8 +1,0 @@
-{
-  "id": "CIosm",
-  "type": "telegram",
-  "account": "OSMCI",
-  "locationSet": {"include": ["ci"]},
-  "languageCodes": ["en"],
-  "strings": {"community": "OpenStreetMap Cote d'Ivoire"}
-}


### PR DESCRIPTION
note: edited online, I have not tested it

note: other Ivory Coast resources may be also dead

fixes #538