### PR TITLE
Upgrade default

### DIFF
--- a/defaults.json
+++ b/defaults.json
@@ -16,7 +16,7 @@
     "facebook": {
       "name": "{community} on Facebook",
       "description": "Join our community on Facebook",
-      "url": "https://facebook.com/{account}"
+      "url": "https://www.facebook.com/{account}"
     },
     "forum": {
       "name": "{community} Forum",
@@ -42,7 +42,7 @@
     "linkedin": {
       "name": "{community} on LinkedIn",
       "description": "Join our community on LinkedIn",
-      "url": "https://linkedin.com/company/{account}"
+      "url": "https://www.linkedin.com/company/{account}"
     },
     "mailinglist": {
       "name": "{account} Mailing List",
@@ -56,7 +56,7 @@
     },
     "meetup": {
       "name": "{community} Meetup",
-      "url": "https://meetup.com/{account}"
+      "url": "https://www.meetup.com/{account}"
     },
     "osm": {
       "name": "{community}"


### PR DESCRIPTION
Add WWW `www.` to websites which redirect to it by default (on mobile, this will automaticly be converted to a mobile view link if present, see ie. Facebook).