### PR TITLE
Don't write _the_ OpenStreetMap

### DIFF
--- a/resources/world/OSMF.json
+++ b/resources/world/OSMF.json
@@ -7,7 +7,7 @@
   "strings": {
     "name": "OpenStreetMap Foundation",
     "description": "OSMF is a UK-based not-for-profit that supports the OpenStreetMap Project",
-    "extendedDescription": "OSMF supports the OpenStreetMap by fundraising, maintaining the servers which power OSM, organizing the annual State of the Map conference, and coordinating the volunteers who keep OSM running. You can show your support and have a voice in the direction of OpenStreetMap by joining as an OSMF member here: {signupUrl}",
+    "extendedDescription": "OSMF supports the OpenStreetMap project by fundraising, maintaining the servers which power OSM, organizing the annual State of the Map conference, and coordinating the volunteers who keep OSM running. You can show your support and have a voice in the direction of OpenStreetMap by joining as an OSMF member here: {signupUrl}",
     "signupUrl": "https://join.osmfoundation.org/",
     "url": "https://wiki.osmfoundation.org/wiki/Main_Page"
   },


### PR DESCRIPTION
OpenStreetMap is typically not written with the article _“the”_. This changes wording in the sentence to _“the OpenStreetMap project”_ instead to fix the grammar.