### PR TITLE
fix spelling of "YouthMappers"

### DIFF
--- a/resources/north-america/belize/ym-Sacred-Heart-Junior-College.json
+++ b/resources/north-america/belize/ym-Sacred-Heart-Junior-College.json
@@ -3,7 +3,7 @@
   "type": "youthmappers",
   "locationSet": {"include": [[-89.07411, 17.161]]},
   "strings": {
-    "name": "Youth Mappers at Sacred Heart Junior College",
+    "name": "YouthMappers at Sacred Heart Junior College",
     "description": "YouthMappers chapter at Sacred Heart Junior College",
     "url": "mailto:jtzib18@gmail.com"
   },


### PR DESCRIPTION
remove superfluous space