### PR TITLE
Add Slovenian discourse category

### DIFF
--- a/resources/europe/slovenia/si-discourse.json
+++ b/resources/europe/slovenia/si-discourse.json
@@ -1,0 +1,11 @@
+{
+  "id": "si-discourse",
+  "type": "discourse",
+  "account": "si",
+  "locationSet": {"include": ["si"]},
+  "languageCodes": ["en", "sl"],
+  "strings": {
+    "community": "OpenStreetMap Slovenia",
+    "name": "{community} Discourse"
+  }
+}


### PR DESCRIPTION
Not to be merged until 

* [x] voting is done on  https://community.openstreetmap.org/t/slovenia-subcategory/3325 and 
* [x] category https://community.openstreetmap.org/c/communities/si is created