### PR TITLE
add Mastodon account for OpenStreetMap Austria

### DIFF
--- a/resources/europe/austria/at-mastodon.json
+++ b/resources/europe/austria/at-mastodon.json
@@ -1,0 +1,14 @@
+{
+  "id": "at-mastodon",
+  "type": "mastodon",
+  "locationSet": {"include": ["at"]},
+  "languageCodes": ["de"],
+  "order": 4,
+  "strings": {
+    "community": "OpenStreetMap Austria",
+    "url": "https://mastodon.social/@osm_at"
+  },
+  "contacts": [
+    {"name": "AT Community", "email": "info@openstreetmap.at"}
+  ]
+}


### PR DESCRIPTION
I added the config file for the Austrian Mastodon account by copying and modifying the one from europe/belgium .