### PR TITLE
fix Ireland Telegram invite

### DIFF
--- a/resources/europe/ireland/ireland-telegram.json
+++ b/resources/europe/ireland/ireland-telegram.json
@@ -6,6 +6,6 @@
   "order": 5,
   "strings": {
     "community": "OpenStreetMap Ireland",
-    "url": "https://t.me/joinchat/BDLI7w9jCWm7Bwm2T06jwQ"
+    "url": "https://t.me/+VNKHmdvvs3qOGTq4"
   }
 }


### PR DESCRIPTION
fix #609

from https://wiki.openstreetmap.org/w/index.php?title=Ireland&curid=1185&diff=2448529&oldid=2442593