### PR TITLE
Add Discourse South Africa

### DIFF
--- a/resources/africa/south_africa/OSM-ZA-discourse.json
+++ b/resources/africa/south_africa/OSM-ZA-discourse.json
@@ -1,0 +1,8 @@
+{
+  "id": "OSM-ZA-discourse",
+  "type": "discourse",
+  "account": "za",
+  "locationSet": {"include": ["za"]},
+  "languageCodes": ["en", "af"],
+  "strings": {"community": "OpenStreetMap South Africa"}
+}


### PR DESCRIPTION
Add South African Discourse community: https://community.openstreetmap.org/c/communities/za

Small but improve visibility to South African mappers.