### PR TITLE
fix link to new website for italian comunity

### DIFF
--- a/resources/europe/italy/it-chapter.json
+++ b/resources/europe/italy/it-chapter.json
@@ -8,14 +8,9 @@
     "community": "OpenStreetMap Italy",
     "communityID": "openstreetmapitaly",
     "description": "We help grow and improve OpenStreetMap in Italy.",
-    "url": "https://www.wikimedia.it/"
+    "url": "https://osmit.it/#chisiamo"
   },
   "contacts": [
-    {"name": "Simone Cortesi", "email": "simone@cortesi.com"},
-    {"name": "Stefano", "email": "sabas88@gmail.com"},
-    {
-      "name": "Alessandro Palmas",
-      "email": "alessandro.palmas@wikimedia.it"
-    }
+    {"name": "Anisa Kuci","email": "anisa.kuci@wikimedia.it"}
   ]
 }


### PR DESCRIPTION
The Italian local chapter of OSMF, Wikimedia Italia, created a new website dedicated to the Italian OSM community. The link is now fixed and more specific with respect to the previous one 