### PR TITLE
Use https for resources and documentation.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -581,7 +581,7 @@ Added:
     * Removed: `featureId` properties and most `.geojson` files (everything that was just a country or a circular point is now gone, as it can be calculated)
     * This approach leverages code from [country-coder](https://github.com/ideditor/country-coder) and [location-conflation](https://github.com/ideditor/location-conflation) projects.
     * `dist/features.json` is now a FeatureCollection that only contains the _custom_ boundaries.
-  * You can now view the community index data on a map at http://openstreetmap.community
+  * You can now view the community index data on a map at https://openstreetmap.community
 
 [#291]: https://github.com/osmlab/osm-community-index/issues/291
 [#298]: https://github.com/osmlab/osm-community-index/issues/298

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -41,4 +41,4 @@ Instances of unacceptable behavior may be reported privately to the project main
 
 #### See Also
 
-This Code of Conduct is adapted from the [Contributor Covenant](http://contributor-covenant.org).
+This Code of Conduct is adapted from the [Contributor Covenant](https://contributor-covenant.org).

--- a/resources/africa/congo/cd-chapter.json
+++ b/resources/africa/congo/cd-chapter.json
@@ -9,7 +9,7 @@
     "name": "OpenStreetMap RDC",
     "description": "From one street to another, let's map our country...",
     "extendedDescription": "We are passionate about the OSM project, sharing some of our time to make the project known to others. We are still too few, join us!",
-    "url": "http://openstreetmap.cd/"
+    "url": "https://openstreetmap.cd/"
   },
   "contacts": [
     {"name": "OpenStreetMap RDC", "email": "contact@openstreetmap.cd"}

--- a/resources/africa/ghana/ym-University-of-Mines-and-Technology.json
+++ b/resources/africa/ghana/ym-University-of-Mines-and-Technology.json
@@ -6,7 +6,7 @@
     "name": "UMaT YouthMappers",
     "description": "YouthMappers chapter at University of Mines and Technology",
     "extendedDescription": "UMaT YouthMappers is a group of volunteer students who seek to grant students the opportunity to improve skills in the field of mapping & creating open geographic data and analyses that address locally defined development challenges worldwide.",
-    "url": "http://umatyouthmappers.wordpress.com/"
+    "url": "https://umatyouthmappers.wordpress.com/"
   },
   "contacts": [
     {"name": "Organizer", "email": "umat.youthmappers@gmail.com"}

--- a/resources/africa/guinea/ym-General-Lansana-Conte-University.json
+++ b/resources/africa/guinea/ym-General-Lansana-Conte-University.json
@@ -6,7 +6,7 @@
     "name": "YouthMappers General Lansana Conte University",
     "description": "YouthMappers chapter at General Lansana Conte University",
     "extendedDescription": "The YouthMappers of the University General Lansana Conté is a non profit community willing to contribute to Map Guinea and others part of the world. We are promoting the use of GIS and Open data to build decision support tools. We also work to build capacities among the students and local communities.",
-    "url": "http://www.uglc.org/"
+    "url": "https://www.uglc.org/"
   },
   "contacts": [{"name": "Organizer", "email": "condefa3@gmail.com"}]
 }

--- a/resources/africa/south_africa/ym-University-of-Pretoria.json
+++ b/resources/africa/south_africa/ym-University-of-Pretoria.json
@@ -6,7 +6,7 @@
     "name": "Centre for Geoinformation Science",
     "description": "YouthMappers chapter at University of Pretoria",
     "extendedDescription": "The students who map Pretoria are supported by the University of Pretoria's Centre for Geoinformation Science, a platform from where the excellence of UP individuals and teams involved in geographic information science (GISc) research, education and training, professional development and community engagement is encouraged and strengthened through collaborations, education and training and  alliances within South Africa and abroad.",
-    "url": "http://www.up.ac.za/cgis"
+    "url": "https://www.up.ac.za/cgis"
   },
   "contacts": [
     {"name": "Organizer", "email": "cgis-info@kendy.up.ac.za"}

--- a/resources/europe/albania/al-maptime-tirana.json
+++ b/resources/europe/albania/al-maptime-tirana.json
@@ -8,7 +8,7 @@
     "name": "Maptime Tirana",
     "description": "Social events organized around mapping - beginners most welcome!",
     "extendedDescription": "Maptime is an open learning environment for all levels and degrees of knowledge, offering intentional educational support for the beginner. Maptime is simultaneously flexible and structured, creating space for mapping tutorials, workshops, ongoing projects with a shared goal, and independent/collaborative work time.",
-    "url": "http://maptime.io/tirana/"
+    "url": "https://maptime.io/tirana/"
   },
   "contacts": [
     {"name": "Jonathan Beliën", "email": "dev@jbelien.be"},

--- a/resources/europe/ukraine/ua-slack.json
+++ b/resources/europe/ukraine/ua-slack.json
@@ -8,7 +8,7 @@
     "community": "OpenStreetMap Ukraine",
     "communityID": "openstreetmapukraine",
     "description": "Join the OpenStreetMap Ukraine community on Slack. Sign up at {signupUrl}",
-    "signupUrl": "http://bit.ly/SlackOsmUa",
+    "signupUrl": "https://bit.ly/SlackOsmUa",
     "url": "https://osmukraine.slack.com/"
   },
   "contacts": [{"name": "Andrii Holovin", "email": "andygol@ua.fm"}]

--- a/resources/europe/united_kingdom/uk-mappamercia.json
+++ b/resources/europe/united_kingdom/uk-mappamercia.json
@@ -8,7 +8,7 @@
     "name": "Mappa Mercia local group",
     "description": "A home for OpenStreetMap enthusiasts in the Midlands",
     "extendedDescription": "Mappa Mercia is a project to grow OpenStreetMap in the West Midlands, UK. We run community events, provide training and support local organisations wishing to open up their data.",
-    "url": "http://www.mappa-mercia.org/"
+    "url": "https://www.mappa-mercia.org/"
   },
   "contacts": [
     {"name": "Brian Prangle", "email": "community@mappa-mercia.org"}

--- a/resources/middle-east/turkey/YerCizenler-TR.json
+++ b/resources/middle-east/turkey/YerCizenler-TR.json
@@ -6,7 +6,7 @@
     "name": "Yer Çizenler",
     "description": "Yer Çizenler Mapping for Everyone Association",
     "extendedDescription": "Yer Çizenler is a local NGO, part of the Turkish OSM community, aiming to promote use of open geospatial data and tools within the national mapping community.",
-    "url": "http://yercizenler.org"
+    "url": "https://yercizenler.org"
   },
   "contacts": [
     {"name": "Corporate Mail", "email": "info@yercizenler.org"},

--- a/resources/north-america/united_states/ym-Clemson-University.json
+++ b/resources/north-america/united_states/ym-Clemson-University.json
@@ -6,7 +6,7 @@
     "name": "Clemson Mappers",
     "description": "YouthMappers chapter at Clemson University",
     "extendedDescription": "Students in Clemson are supported by the Center for Geospatial Technologies, a community of interdisciplinary geospatial science practitioners supporting research, teaching, and outreach activities using technologies that enable the collection, analysis, and application of geospatial data. Students integrate geospatial technologies within their scholarly activities across all disciplines and build connections throughout the world.",
-    "url": "http://www.clemsongis.org/#!clemson-mappers/i9w6t"
+    "url": "https://www.clemsongis.org/#!clemson-mappers/i9w6t"
   },
   "contacts": [
     {"name": "Organizer", "email": "clemsonmappers@gmail.com"}

--- a/resources/north-america/united_states/ym-University-of-Oregon.json
+++ b/resources/north-america/united_states/ym-University-of-Oregon.json
@@ -6,7 +6,7 @@
     "name": "Map by Northwest",
     "description": "YouthMappers chapter at University of Oregon",
     "extendedDescription": "Map By Northwest aims to engage undergraduate students at the University of Oregon in mapping projects to assist in humanitarian causes and for conducting geographic research. We welcome students from all disciplines to join us in our mapping adventures.",
-    "url": "http://blogs.uoregon.edu/mxnw/"
+    "url": "https://blogs.uoregon.edu/mxnw/"
   },
   "contacts": [{"name": "Organizer", "email": "cbone@uoregon.edu"}]
 }

--- a/resources/north-america/united_states/ym-University-of-Wyoming.json
+++ b/resources/north-america/united_states/ym-University-of-Wyoming.json
@@ -5,7 +5,7 @@
   "strings": {
     "name": "Gamma Theta Upsilon/Geography Club",
     "description": "YouthMappers chapter at University of Wyoming",
-    "url": "http://www.uwyo.edu/geography/geographyclub/"
+    "url": "https://www.uwyo.edu/geography/geographyclub/"
   },
   "contacts": [
     {"name": "Organizer", "email": "gtu-geography@uwyo.edu"}

--- a/resources/north-america/united_states/ym-Vassar-College.json
+++ b/resources/north-america/united_states/ym-Vassar-College.json
@@ -6,7 +6,7 @@
     "name": "Hudson Valley Mappers",
     "description": "YouthMappers chapter at Vassar College",
     "extendedDescription": "Our mission is to provide a multi-disciplinary platform for peers, educators, and community organizations to engage in local mapping projects with a focus on strengthening our local ecosystems, our built environment, and the health of our community. We also seek to contribute geospatial support for global humanitarian aid and development efforts.",
-    "url": "http://pages.vassar.edu/gis/vassar-youthmappers/"
+    "url": "https://pages.vassar.edu/gis/vassar-youthmappers/"
   },
   "contacts": [{"name": "Organizer", "email": "geo@vassar.edu"}]
 }

--- a/resources/south-america/argentina/OSM-AR-geolibres.json
+++ b/resources/south-america/argentina/OSM-AR-geolibres.json
@@ -10,6 +10,6 @@
     "name": "GeoLibres",
     "description": "Geolibres Civil Association",
     "extendedDescription": "We promote the creation and use of free access geographic data, the adoption of geographic standards, and the use of free and open source software.",
-    "url": "http://geolibres.org.ar/"
+    "url": "https://geolibres.org.ar/"
   }
 }

--- a/resources/south-america/peru/OSM-PE.json
+++ b/resources/south-america/peru/OSM-PE.json
@@ -7,7 +7,7 @@
     "community": "OpenStreetMap Peru",
     "communityID": "openstreetmapperu",
     "description": "News and resources for the OpenStreetMap Peru community",
-    "url": "http://osmpe.ourproject.org/"
+    "url": "https://osmpe.ourproject.org/"
   },
   "contacts": [
     {


### PR DESCRIPTION
I noticed today on openstreetmap.org that some chapter links were not using `https`, so I made some investigations. This PR updates all of the resources and documentation that used `http` to use `https`, where:
* The `http` version redirects to `https` (checked with `curl -I`, received a 301 or 302 response) - that was most of them, or
* The `http` version doesn't redirect, but serves the same content as the `https` version ( https://www.uwyo.edu/geography/geographyclub/ and https://bit.ly/SlackOsmUa )

There were two resources that I didn't update, since they need further investigation:

* resources/africa/nigeria/ym-Federal-University-of-Technology-Akure.json:9:    "url": "http://spaceclubfuta.com.ng/" - domain not found
* resources/asia/bangladesh/ym-Asian-University-for-Women.json:9:    "url": "http://www.auw.edu.bd/" - no redirect, but some kind of in-browser redirect to a completely different domain.

These two could be addressed separately.

In addition, there is some json-schema-related files that I haven't changed either, they could again be addressed separately.

Refs #533