### PR TITLE
Revert "Remove OpenStreetMap Türkiye telegram group, requires payment"

### DIFF
--- a/resources/middle-east/turkey/tr-telegram.json
+++ b/resources/middle-east/turkey/tr-telegram.json
@@ -1,0 +1,8 @@
+{
+  "id": "tr-telegram",
+  "type": "telegram",
+  "account": "osm_tr",
+  "locationSet": {"include": ["tr"]},
+  "languageCodes": ["tr"],
+  "strings": {"community": "OpenStreetMap Turkey"}
+}


### PR DESCRIPTION
This reverts commit 5cc17a681f4ca1e238a08e1643944a8041bd9305.

Apparently it was some hiccup/mistake/temporary state/Telegram bug and can be accessed per https://github.com/osmlab/osm-community-index/issues/641#issuecomment-1427133677 (but I have not verified it)

fixes #641

(note: my node is not recent enough per https://github.com/osmlab/osm-community-index/blob/main/package.json#L87 to run `npm run test` mentioned in https://github.com/osmlab/osm-community-index/wiki/Contributing)