### PR TITLE
added "en" language code to the bz-telegram.json file

### DIFF
--- a/resources/north-america/belize/bz-telegram.json
+++ b/resources/north-america/belize/bz-telegram.json
@@ -3,7 +3,7 @@
   "type": "telegram",
   "account": "osm_bz",
   "locationSet": {"include": ["bz"]},
-  "languageCodes": ["es"],
+  "languageCodes": ["en", "es"],
   "strings": {
     "community": "OpenStreetMap Belize",
     "communityID": "openstreetmapbelize"


### PR DESCRIPTION
I added the "en" language to the bz-telegram.json file because of this error on the Id Editor page "[Missing en translation: community._communities.openstreetmapbelize Telegram](https://t.me/osm_bz)"