### PR TITLE
Add OSM Singapore Wiki and Telegram, OSM Armenia Wiki

### DIFF
--- a/resources/asia/singapore/sg-telegram.json
+++ b/resources/asia/singapore/sg-telegram.json
@@ -1,0 +1,11 @@
+{
+  "id": "sg-telegram",
+  "type": "telegram",
+  "account": "osm_singapore",
+  "locationSet": {"include": ["sg"]},
+  "order": 3,
+  "strings": {
+    "community": "OpenStreetMap Singapore",
+    "communityID": "openstreetmapsingapore"
+  }
+}

--- a/resources/asia/singapore/sg-wiki.json
+++ b/resources/asia/singapore/sg-wiki.json
@@ -1,0 +1,12 @@
+{
+  "id": "sg-wiki",
+  "type": "wiki",
+  "account": "Singapore",
+  "locationSet": {"include": ["sg"]},
+  "order": 4,
+  "strings": {
+    "community": "OpenStreetMap Singapore",
+    "communityID": "openstreetmapsingapore",
+    "description": "{community} Wiki page"
+  }
+}

--- a/resources/europe/armenia/am-wiki.json
+++ b/resources/europe/armenia/am-wiki.json
@@ -1,0 +1,12 @@
+{
+  "id": "am-wiki",
+  "type": "wiki",
+  "account": "Armenia",
+  "locationSet": {"include": ["am"]},
+  "order": 4,
+  "strings": {
+    "community": "OpenStreetMap Armenia",
+    "communityID": "openstreetmaparmenia",
+    "description": "{community} Wiki page"
+  }
+}


### PR DESCRIPTION
I created osm_armenia Telegram group back in 2022 when I lived there. Now I'm going to visit Singapore and I'm really surprised there is no chat/group for this country. Let's create one. I have just updated the corresponding [wiki page](https://wiki.openstreetmap.org/wiki/List_of_OSM_centric_Telegram_accounts).

This commit also adds links to the existing OSM wiki pages for Armenia and Singapore.