### PR TITLE
Improved PT and BR order and added BR wiki

### DIFF
--- a/resources/europe/portugal/pt-discord.json
+++ b/resources/europe/portugal/pt-discord.json
@@ -4,6 +4,7 @@
   "account": "Uhggtd7XpK",
   "locationSet": {"include": ["pt"]},
   "languageCodes": ["pt"],
+  "order": 2,
   "strings": {
     "community": "OpenStreetMap Portugal",
     "communityID": "openstreetmapportugal"

--- a/resources/europe/portugal/pt-discourse.json
+++ b/resources/europe/portugal/pt-discourse.json
@@ -4,7 +4,7 @@
   "account": "pt",
   "locationSet": {"include": ["pt"]},
   "languageCodes": ["pt"],
-  "order": 0,
+  "order": 4,
   "strings": {
     "community": "OpenStreetMap Portugal",
     "communityID": "openstreetmapportugal"

--- a/resources/europe/portugal/pt-discourse.json
+++ b/resources/europe/portugal/pt-discourse.json
@@ -4,6 +4,7 @@
   "account": "pt",
   "locationSet": {"include": ["pt"]},
   "languageCodes": ["pt"],
+  "order": 0,
   "strings": {
     "community": "OpenStreetMap Portugal",
     "communityID": "openstreetmapportugal"

--- a/resources/europe/portugal/pt-telegram.json
+++ b/resources/europe/portugal/pt-telegram.json
@@ -4,7 +4,7 @@
   "account": "OSMPortugal",
   "locationSet": {"include": ["pt"]},
   "languageCodes": ["pt"],
-  "order": 1,
+  "order": 3,
   "strings": {
     "community": "OpenStreetMap Portugal",
     "communityID": "openstreetmapportugal"

--- a/resources/europe/portugal/pt-telegram.json
+++ b/resources/europe/portugal/pt-telegram.json
@@ -4,6 +4,7 @@
   "account": "OSMPortugal",
   "locationSet": {"include": ["pt"]},
   "languageCodes": ["pt"],
+  "order": 1,
   "strings": {
     "community": "OpenStreetMap Portugal",
     "communityID": "openstreetmapportugal"

--- a/resources/europe/portugal/pt-wiki.json
+++ b/resources/europe/portugal/pt-wiki.json
@@ -3,7 +3,7 @@
   "type": "wiki",
   "locationSet": {"include": ["pt"]},
   "languageCodes": ["en", "pt"],
-  "order": 3,
+  "order": 1,
   "strings": {
     "community": "OpenStreetMap Portugal",
     "communityID": "openstreetmapportugal",

--- a/resources/europe/portugal/pt-wiki.json
+++ b/resources/europe/portugal/pt-wiki.json
@@ -3,6 +3,7 @@
   "type": "wiki",
   "locationSet": {"include": ["pt"]},
   "languageCodes": ["en", "pt"],
+  "order": 3,
   "strings": {
     "community": "OpenStreetMap Portugal",
     "communityID": "openstreetmapportugal",

--- a/resources/south-america/brazil/br-discord.json
+++ b/resources/south-america/brazil/br-discord.json
@@ -4,7 +4,7 @@
   "account": "bQn4aCm",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 4,
+  "order": 2,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"

--- a/resources/south-america/brazil/br-discord.json
+++ b/resources/south-america/brazil/br-discord.json
@@ -4,7 +4,7 @@
   "account": "bQn4aCm",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 2,
+  "order": 5,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"

--- a/resources/south-america/brazil/br-discord.json
+++ b/resources/south-america/brazil/br-discord.json
@@ -4,7 +4,7 @@
   "account": "bQn4aCm",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 5,
+  "order": 4,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"

--- a/resources/south-america/brazil/br-discourse.json
+++ b/resources/south-america/brazil/br-discourse.json
@@ -4,7 +4,7 @@
   "account": "br",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 0,
+  "order": 4,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"

--- a/resources/south-america/brazil/br-discourse.json
+++ b/resources/south-america/brazil/br-discourse.json
@@ -4,6 +4,7 @@
   "account": "br",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
+  "order": 0,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"

--- a/resources/south-america/brazil/br-telegram.json
+++ b/resources/south-america/brazil/br-telegram.json
@@ -4,7 +4,7 @@
   "account": "OSMBrasil_Comunidade",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 1,
+  "order": 3,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil",

--- a/resources/south-america/brazil/br-twitter.json
+++ b/resources/south-america/brazil/br-twitter.json
@@ -4,7 +4,7 @@
   "account": "OpenStreetMapBR",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 3,
+  "order": 1,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"

--- a/resources/south-america/brazil/br-wiki.json
+++ b/resources/south-america/brazil/br-wiki.json
@@ -1,0 +1,13 @@
+{
+  "id": "br-wiki",
+  "type": "wiki",
+  "locationSet": {"include": ["br"]},
+  "languageCodes": ["en", "pt"],
+  "order": 0,
+  "strings": {
+    "community": "OpenStreetMap Brasil",
+    "communityID": "openstreetmapbrasil",
+    "description": "WikiProject with information and coordination guidelines for mapping in Brazil.",
+    "url": "https://wiki.openstreetmap.org/wiki/Brazil"
+  }
+}

--- a/resources/south-america/brazil/talk-br.json
+++ b/resources/south-america/brazil/talk-br.json
@@ -4,7 +4,7 @@
   "account": "talk-br",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 0,
+  "order": -3,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"

--- a/resources/south-america/brazil/talk-br.json
+++ b/resources/south-america/brazil/talk-br.json
@@ -4,7 +4,7 @@
   "account": "talk-br",
   "locationSet": {"include": ["br"]},
   "languageCodes": ["pt"],
-  "order": 5,
+  "order": 0,
   "strings": {
     "community": "OpenStreetMap Brasil",
     "communityID": "openstreetmapbrasil"


### PR DESCRIPTION
Hey guys!

Local community asked, and also based on my experience, I'm trying to fix the order of elements, both in Portugal and Brazil. In Brazil I also added the missing wiki page.

(Sorry for many commits, I had wrongly understood the 'order' value so had to redo everything hehe).

Please let me know if there's anything else to be done or fixed.