### PR TITLE
Fix mailinglist url for mainz

### DIFF
--- a/resources/europe/germany/de-mainz-mailinglist.json
+++ b/resources/europe/germany/de-mainz-mailinglist.json
@@ -7,6 +7,7 @@
   "strings": {
     "community": "OSM Mainz",
     "communityID": "osmmainz",
-    "description": "OpenStreetMap in Mainz und Umgebung"
+    "description": "OpenStreetMap in Mainz und Umgebung",
+    "url": "https://lists.openstreetmap.de/listinfo/mainz"
   }
 }


### PR DESCRIPTION
Fixup for #707, thanks @moschlar and @bhousel for the initial addition and review :heart: 

Currently wrong mailing list url: https://lists.openstreetmap.org/listinfo/mainz (org)
Correct mailing list url: https://lists.openstreetmap.de/listinfo/mainz (de)
Preview: https://openstreetmap.community/?map=49.79900,8.31769&zoom=8.87


I used Stuttgart as a template: https://github.com/osmlab/osm-community-index/blob/a85e277e5bdf009f8c63d736192acacb3c62d8c1/resources/europe/germany/de-stuttgart-mailinglist.json#L7-L11