### PR TITLE
Update cyprus-matrix.json to encompass entirety of the island

### DIFF
--- a/resources/europe/cyprus/cyprus-matrix.json
+++ b/resources/europe/cyprus/cyprus-matrix.json
@@ -2,7 +2,7 @@
   "id": "cyprus-matrix",
   "type": "matrix",
   "account": "#osm-cyprus",
-  "locationSet": {"include": ["cy"]},
+  "locationSet": {"include": ["Q644636"]},
   "languageCodes": ["en"],
   "order": 2,
   "strings": {


### PR DESCRIPTION
Update to the wikidata tag in order to encompass the entire island, instead of just the Republic of Cyprus controlled portion; therefore incluidng RoC, TRoNC and British sovereign bases.