### PR TITLE
Add MapLYH Signal group for Lynchburg, Virginia, USA

### DIFF
--- a/resources/north-america/united_states/MapLYH.json
+++ b/resources/north-america/united_states/MapLYH.json
@@ -1,0 +1,12 @@
+{
+  "id": "MapLYH",
+  "type": "signal",
+  "locationSet": {"include": [[-79.1798, 37.3923]]},
+  "languageCodes": ["en"],
+  "strings": {
+    "name": "MapLYH",
+    "description": "MapLYH group",
+    "url": "https://signal.group/#CjQKIL1jGgWB33mnMdfvh55Ku0bn_InsGxfoYDVIYL0Q_6TeEhAWYhTVF5l_8sofCOldYZbW"
+  },
+  "contacts": [{"name": "Signal Admin", "email": "maplyh@nathanwyand.com"}]
+}


### PR DESCRIPTION
MapLYH has a small Signal group where we communicate to coordinate mapping, organize surveys, and discuss best practices. This commit adds MapLYH and a link to the Signal group to the map.