### PR TITLE
add Discord channel for Japanese community

### DIFF
--- a/resources/asia/japan/OSM-Japan-discord.json
+++ b/resources/asia/japan/OSM-Japan-discord.json
@@ -1,13 +1,13 @@
 {
-  "id": "OSM-japan-slack",
-  "type": "slack",
+  "id": "OSM-japan-discord",
+  "type": "discord",
   "locationSet": {"include": ["jp"]},
   "languageCodes": ["ja"],
   "strings": {
     "community": "OpenStreetMap Japan",
     "communityID": "openstreetmapjapan",
-    "description": "Deprecated: A Slack workspace for the OSM Japan community",
-    "url": "https://osm-japan.slack.com/"
+    "description": "A Discord workspace for the OSM Japan community {signupUrl}",
+    "signupUrl": "https://discord.gg/pNuUM99kUX"
   },
   "contacts": [{"name": "OSMF Japan", "email": "info@osmf.jp"}]
 }


### PR DESCRIPTION
The Japanese community has opened a Discord channel as a new chat platform.

Consequently, the Slack channel will be deprecated.