### PR TITLE
Add Africa community forum

### DIFF
--- a/resources/africa/osm-africa-discourse.json
+++ b/resources/africa/osm-africa-discourse.json
@@ -1,0 +1,12 @@
+{
+  "id": "osm-africa-discourse",
+  "type": "discourse",
+  "account": "africa",
+  "locationSet": {"include": ["002"]},
+  "languageCodes": ["en", "fr"],
+  "order": 2,
+  "strings": {
+    "community": "OpenStreetMap Africa",
+    "communityID": "openstreetmapafrica"
+  }
+}

--- a/resources/africa/osm-africa-eventbrite.json
+++ b/resources/africa/osm-africa-eventbrite.json
@@ -3,6 +3,7 @@
   "type": "url",
   "locationSet": {"include": ["002"]},
   "languageCodes": ["en", "fr"],
+  "order": -3,
   "strings": {
     "community": "OpenStreetMap Africa",
     "communityID": "openstreetmapafrica",

--- a/resources/africa/osm-africa-facebook-group.json
+++ b/resources/africa/osm-africa-facebook-group.json
@@ -3,6 +3,7 @@
   "type": "facebook",
   "locationSet": {"include": ["002"]},
   "languageCodes": ["en", "fr"],
+  "order": -1,
   "strings": {
     "community": "OpenStreetMap Africa",
     "communityID": "openstreetmapafrica",

--- a/resources/africa/osm-africa-facebook.json
+++ b/resources/africa/osm-africa-facebook.json
@@ -3,6 +3,7 @@
   "type": "facebook",
   "account": "OpenStreetMapAfrica",
   "locationSet": {"include": ["002"]},
+  "order": -2,
   "strings": {
     "community": "OpenStreetMap Africa",
     "communityID": "openstreetmapafrica"

--- a/resources/africa/osm-africa-matrix.json
+++ b/resources/africa/osm-africa-matrix.json
@@ -4,6 +4,7 @@
   "account": "#osmafrica",
   "locationSet": {"include": ["002"]},
   "languageCodes": ["en", "fr"],
+  "order": 1,
   "strings": {
     "community": "OpenStreetMap Africa",
     "communityID": "openstreetmapafrica",

--- a/resources/africa/osm-africa-slack.json
+++ b/resources/africa/osm-africa-slack.json
@@ -3,6 +3,7 @@
   "type": "slack",
   "locationSet": {"include": ["002"]},
   "languageCodes": ["en", "fr"],
+  "order": 1,
   "strings": {
     "community": "OpenStreetMap Africa",
     "communityID": "openstreetmapafrica",

--- a/resources/africa/osm-africa-telegram.json
+++ b/resources/africa/osm-africa-telegram.json
@@ -3,6 +3,7 @@
   "type": "telegram",
   "account": "OSMAfrica",
   "locationSet": {"include": ["002"]},
+  "order": 1,
   "strings": {
     "community": "OpenStreetMap Africa",
     "communityID": "openstreetmapafrica"

--- a/resources/africa/osm-africa-twitter.json
+++ b/resources/africa/osm-africa-twitter.json
@@ -3,6 +3,7 @@
   "type": "twitter",
   "account": "osmafrica",
   "locationSet": {"include": ["002"]},
+  "order": -2,
   "strings": {
     "community": "OpenStreetMap Africa",
     "communityID": "openstreetmapafrica"


### PR DESCRIPTION
Reprioritise other entries:
Chat-channels seem quite active, with more than thousand members in Matrix

Facebook group has no entries last month
Facebook account, Twitter and Eventbrite on bottom, given only being information channels

Mailing list has almost no real activity, mostly spam from the weeklyOSM newsletter

Part of effort to add all remaining community forums to the index, as not all communities are aware of this repository: https://community.openstreetmap.org/t/add-all-community-forums-to-the-community-index/119315