### PR TITLE
Add Croatia community forum

### DIFF
--- a/resources/europe/croatia/hr-discourse.json
+++ b/resources/europe/croatia/hr-discourse.json
@@ -1,0 +1,12 @@
+{
+  "id": "hr-discourse",
+  "type": "discourse",
+  "account": "hr",
+  "locationSet": {"include": ["hr"]},
+  "languageCodes": ["hr"],
+  "order": 4,
+  "strings": {
+    "community": "OpenStreetMap Croatia",
+    "communityID": "openstreetmapcroatia"
+  }
+}

--- a/resources/europe/croatia/hr-mailinglist.json
+++ b/resources/europe/croatia/hr-mailinglist.json
@@ -4,7 +4,7 @@
   "account": "talk-hr",
   "locationSet": {"include": ["hr"]},
   "languageCodes": ["hr"],
-  "order": 3,
+  "order": -4,
   "strings": {
     "community": "OpenStreetMap Croatia",
     "communityID": "openstreetmapcroatia"


### PR DESCRIPTION
Currently recommended Facebook don't have too much activity, so placing community forum on top

Mailing list not used since 2023, so pushing to bottom

Link to IRC is dead for me, but not an IRC expert