### PR TITLE
Remove Italy Facebook prioritization

### DIFF
--- a/resources/europe/italy/it-facebook.json
+++ b/resources/europe/italy/it-facebook.json
@@ -4,7 +4,6 @@
   "account": "OpenStreetMap.Italia",
   "locationSet": {"include": ["it"]},
   "languageCodes": ["it"],
-  "order": 3,
   "strings": {
     "community": "OpenStreetMap Italy",
     "communityID": "openstreetmapitaly"


### PR DESCRIPTION
No posts since 2023, so the default order applied in commit 75d2f15 is no longer good