### PR TITLE
delete talk-nz

### DIFF
--- a/resources/oceania/new_zealand/talk-nz.json
+++ b/resources/oceania/new_zealand/talk-nz.json
@@ -1,9 +1,0 @@
-{
-  "id": "talk-nz",
-  "type": "mailinglist",
-  "account": "talk-nz",
-  "locationSet": {"include": ["nz"]},
-  "languageCodes": ["en"],
-  "order": -3,
-  "strings": {"description": "New Zealand's OSM community talk"}
-}


### PR DESCRIPTION
The `talk-nz` mailing list no longer appears on http://lists.osm.org. If you had the link bookmarked, you can see [a message](https://lists.osm.org/listinfo/talk-nz) that confirms that the list is dead.

these days some people use #aotearoa on slack, others use #oceania on discord, and a few people use #oceania on the forum