### PR TITLE
Fix language code for Estonian projects

### DIFF
--- a/resources/europe/estonia/ee-discourse.json
+++ b/resources/europe/estonia/ee-discourse.json
@@ -3,7 +3,7 @@
   "type": "discourse",
   "account": "ee",
   "locationSet": {"include": ["ee"]},
-  "languageCodes": ["ee", "en"],
+  "languageCodes": ["et", "en"],
   "order": 2,
   "strings": {
     "community": "OpenStreetMap Estonia",

--- a/resources/europe/estonia/ee-wiki.json
+++ b/resources/europe/estonia/ee-wiki.json
@@ -2,7 +2,7 @@
   "id": "ee-wiki",
   "type": "wiki",
   "locationSet": {"include": ["ee"]},
-  "languageCodes": ["ee", "en"],
+  "languageCodes": ["et", "en"],
   "strings": {
     "community": "OpenStreetMap Estonia",
     "communityID": "openstreetmapestonia",

--- a/resources/europe/estonia/talk-ee.json
+++ b/resources/europe/estonia/talk-ee.json
@@ -3,7 +3,7 @@
   "type": "mailinglist",
   "account": "talk-ee",
   "locationSet": {"include": ["ee"]},
-  "languageCodes": ["ee", "en"],
+  "languageCodes": ["et", "en"],
   "order": 1,
   "strings": {
     "community": "OpenStreetMap Estonia",


### PR DESCRIPTION
Language code for Estonian (et) is different from country code for Estonia (ee).
These projects are associated to Estonian (et) language not Ewe (ee) language.